### PR TITLE
Republish discovery configs on every MQTT reconnect

### DIFF
--- a/garbage_bin/main.py
+++ b/garbage_bin/main.py
@@ -297,7 +297,6 @@ def main():
     connect_mqtt(mqtt_client, mqtt_config["host"], int(mqtt_config["port"]))
     mqtt_client.subscribe("homeassistant/status")
     mqtt_client.loop_start()
-    publish_discovery(mqtt_client, devices, lwt)
 
     # curl -X GET -H "Authorization: Bearer config['hass']['token'] -H "Content-Type: application/json" http://homeassistant.home:8123/api/states/binary_sensor.garbage_bin_ha | python -m json.tool
     sd.notify("READY=1")

--- a/garbage_bin/main.py
+++ b/garbage_bin/main.py
@@ -110,6 +110,9 @@ def on_connect(client, userdata, flags, reason_code, properties):
     client.publish("garagecam/status", "online", retain=True)
     client.publish("garagecam/process/state", "running", retain=True)
     client.publish("garagecam/version/state", get_version(), retain=True)
+    # Republish discovery so HA recovers from a broker restart that drops retained messages.
+    if userdata:
+        publish_discovery(client, userdata["devices"], userdata["lwt"])
 
 
 def on_disconnect(client, userdata, flags, reason_code, properties):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -65,6 +65,25 @@ def test_on_connect_publishes_status_and_process_state(mocker):
     client.publish.assert_any_call("garagecam/version/state", "v1.0.0", retain=True)
 
 
+def test_on_connect_republishes_discovery_when_userdata_set(mocker):
+    """on_connect republishes discovery so HA recovers from broker restarts."""
+    mocker.patch("garbage_bin.main.get_version", return_value="v1.0.0")
+    spy = mocker.patch("garbage_bin.main.publish_discovery")
+    client = mocker.MagicMock()
+    devices = [mocker.MagicMock()]
+    userdata = {"devices": devices, "lwt": "garagecam/status"}
+    on_connect(client, userdata, None, 0, None)
+    spy.assert_called_once_with(client, devices, "garagecam/status")
+
+
+def test_on_connect_skips_discovery_when_userdata_missing(mocker):
+    """A None userdata must not raise (defensive guard for any first-connect race)."""
+    mocker.patch("garbage_bin.main.get_version", return_value="v1.0.0")
+    spy = mocker.patch("garbage_bin.main.publish_discovery")
+    on_connect(mocker.MagicMock(), None, None, 0, None)
+    spy.assert_not_called()
+
+
 def test_on_disconnect_clean(mocker, caplog):
     """Clean disconnect (reason_code 0) logs at info level."""
     import logging
@@ -323,7 +342,7 @@ def test_on_message_ignores_ha_offline(mocker):
 
 
 def test_main_setup_and_immediate_exit(mocker):
-    """Exercise main() setup: MQTT wiring, subscribe, and publish_discovery call."""
+    """Exercise main() setup: MQTT wiring, subscribe, and callback registration."""
     mocker.patch("garbage_bin.main.sdnotify.SystemdNotifier")
     mocker.patch("garbage_bin.main.YOLO")
     config = configparser.ConfigParser()
@@ -357,7 +376,7 @@ def test_main_setup_and_immediate_exit(mocker):
     assert len(call_kwargs.kwargs["userdata"]["devices"]) == 3
     # Verify subscribed to homeassistant/status
     mock_client_instance.subscribe.assert_called_once_with("homeassistant/status")
-    # Verify publish_discovery was called
-    mock_publish_disc.assert_called_once()
+    # Discovery is now driven by on_connect, not main(), so main() should not call it directly.
+    mock_publish_disc.assert_not_called()
     # Verify on_message callback was wired
     assert mock_client_instance.on_message is not None


### PR DESCRIPTION
## Summary
- Adds a `publish_discovery(...)` call to `on_connect` so the detector republishes Home Assistant MQTT discovery configs after every reconnect, not only on the initial run and HA birth.

## Why
Discovered today: when the Mosquitto broker on `attic` restarts and its retained store is dropped (e.g. before persistence was enabled, or a DB roll), HA entities for `garbage_bin`, `honda_civic`, `honda_crv`, etc. silently go `unavailable` because their discovery configs vanish from the broker.

Previously discovery was published only:
- once in `main()` at startup, and
- in `on_message` when HA fires its `homeassistant/status=online` birth message.

A broker restart while HA stays up matches neither path. The detector reconnects via paho's auto-reconnect, but `on_connect` only refreshes a few status topics — discovery configs stay missing, HA stays orphaned.

## Test plan
- [x] Confirmed manually: with the broker's retained store cleared, restarting the broker without this fix leaves HA entities unavailable; with the fix, they recover within seconds of the detector's auto-reconnect.
- [ ] CI builds new `:latest` image; container's `AutoUpdate=registry` pulls and restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Home Assistant discovery entities would be lost when the MQTT broker restarts. The system now properly recovers and repopulates these entities upon reconnection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/brianegge/garbage_bin/pull/299)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->